### PR TITLE
🛠️ fix: Correct column span in tutorials table

### DIFF
--- a/src/pages/admin/tutorials/ListTutorial.tsx
+++ b/src/pages/admin/tutorials/ListTutorial.tsx
@@ -143,7 +143,7 @@ const ListTutorials: React.FC = () => {
             <tbody>
               { currentTutorials.length === 0 ? (
                 <tr>
-                  <td colSpan={ 5 } className="text-center">
+                  <td colSpan={ 7 } className="text-center">
                   No tutorials found
                   </td>
                 </tr>


### PR DESCRIPTION
Adjust column span from 5 to 7 in the tutorials list table to match the current table structure. This ensures proper alignment and display when no tutorials are found.